### PR TITLE
Update bio text

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Generated with [Bati](https://batijs.dev) ([version 270](https://www.npmjs.com/p
 bun create bati --react --tailwindcss --eslint
 ```
 
+# Hosting
+
+This site is hosted on [Render](https://render.com), with deploys connected to this GitHub repository via GitHub OAuth (sign in to the Render dashboard with GitHub to manage the service).
+
 # Deploy
 
 Build:

--- a/pages/index/+Page.tsx
+++ b/pages/index/+Page.tsx
@@ -5,9 +5,9 @@ export { Page }
 
 function Page() {
   const blurbParagraphs: React.ReactNode[] = [
-    "Hannah Kofman has an MFA from Washington University in St. Louis. Her work has appeared in the Los Angeles Review of Books, T Magazine, MUBI notebook, and Michigan Quarterly Review.",
-    "In 2025, her story won the Carrie Scott Galt Writer's award and she was a semi-finalist for the Fine Arts Work Fellowship. Her stories have been shortlisted for the Disquiet Literary Prize and longlisted for the Ploughshares Emerging Writer's Contest and the A Public Space Fellowship. She has received support from the Sewanee Writers' Conference, Under the Volcano, VCCA, Disquiet International, Tin House, and NY State Writers Institute.",
-    "She's interned at Dorothy, a publishing project, Los Angeles Review of Books, and O, Oprah Magazine in the books department. She's also worked on a farm, in a restaurant, and as a tutor. Her fiction is interested in the narcissism of suffering and the intricacies of family relationships. She's currently working on a novel and a short story collection.",
+    "Hannah Kofman is a writer living in Los Angeles. She has an MFA from Washington University in St. Louis, where she won the Carrie Scott Galt Writer's award. Her work has appeared in T Magazine, Los Angeles Review of Books, MUBI notebook, and Michigan Quarterly Review. Her short fiction earned honorable mention in the 2026 Waasnode Fiction Prize and will appear in a forthcoming issue of Passages North. Her stories have also been shortlisted for the Disquiet Literary Prize and longlisted for the Ploughshares Emerging Writers Award and A Public Space Fellowship. She has received support from the Sewanee Writers' Conference, Under the Volcano, VCCA, New York State Writers Institute, Disquiet International, and Tin House.",
+    "She's interned at Dorothy, a publishing project, Los Angeles Review of Books, and O, Oprah Magazine in the books department. She's also worked on a farm, in a restaurant, and as a tutor.",
+    "She is currently working on a novel and a short story collection.",
     "You can reach her via email at kofman.hannah@gmail.com"
   ];
 


### PR DESCRIPTION
Updates the homepage bio with new copy, including LA location, the 2026 Waasnode Fiction Prize honorable mention / forthcoming Passages North story, and refreshed awards and work history. Now split into three paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)